### PR TITLE
Add disclaimer about cleaning gradle (laskarit 1)

### DIFF
--- a/laskarit/1.md
+++ b/laskarit/1.md
@@ -331,6 +331,7 @@ ja suorittamalla komento <code>gradle test jacocoTestReport</code>
 * näet html-muodossa olevean testien rivikattavuusraportin avaamalla selaimella tiedoston _build/reports/jacoco/test/html/index.html_
   * pääset klikkailemalla luokkien ja metodien nimiä näkemään mitkä rivit ovat vielä testien ulottumattomissa
   * **HUOM** jos jacoco aiheuttaa virheilmoituksen _Could not resolve all files for configuration ':jacocoAgent'._ , vaihda tiedostosta _build.gradle_ merkkijono _jcenter()_ muotoon _mavenCentral()_
+  * **HUOM2** jos gradle ilmoittaa _:jacocoTestReport SKIPPED_, suorita komento <code>gradle clean</code> ja yritä uudelleen.
 
 * kun luokan <code>Varasto</code> testien rivikattavuus (line coverage) on 100%, pushaa tekemäsi muutokset GitHubiin
 


### PR DESCRIPTION
When the JaCoCo plugin is applied the tests have already been created so gradle won't update them, resulting in the task "test" being reported as "UP-TO-DATE" and therefore the task "jacocoTestReport" is reported as "SKIPPED". A simple clean fixes it.