### PR TITLE
Typo ja macillä toimiva muutos

### DIFF
--- a/web/gradle.md
+++ b/web/gradle.md
@@ -439,7 +439,6 @@ repositories {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'junit:junit:4.12'
 }
 </pre>
 

--- a/web/gradle.md
+++ b/web/gradle.md
@@ -324,7 +324,7 @@ Exception in thread "main" java.util.NoSuchElementException: No line found
 FAILURE: Build failed with an exception.
 </pre>
 
-Syynä tälle on se, että oletusarvoisesti gradlen _run_-task ei liitä terminaalia systeein "inputvirtaan". Asia saadaan korjautumaan lisäämällä tiedostoon _build.gradle_ seuraava: 
+Syynä tälle on se, että oletusarvoisesti gradlen _run_-task ei liitä terminaalia system.in "inputvirtaan". Asia saadaan korjautumaan lisäämällä tiedostoon _build.gradle_ seuraava: 
 
 <pre>
 run {
@@ -439,6 +439,7 @@ repositories {
 
 dependencies {
     testCompile 'junit:junit:4.12'
+    compile 'junit:junit:4.12'
 }
 </pre>
 


### PR DESCRIPTION
OSX:llä ei toiminut testit, ennen kuin lisäsi ko koodin build.gradleen.
Lause -systeein "inputvirtaan"- ei vaikuttanut oikeelliselta. Onko siis systeemin vai system.in?