### PR TITLE
Viikon 2 palaute ja korjauksia

### DIFF
--- a/laskarit/2.md
+++ b/laskarit/2.md
@@ -154,7 +154,7 @@ Välilehdellä "code patterns" on mahdollista määritellä projektikohtaisesti,
 
 Lisää vielä joku muu projektisi, esim. ohjelmoinnin harjoitustyö codacyn tarkkailtavaksi ja katso mitä ongelmia koodista löytyy.
 
-[Code Climate](https://codeclimate.com) on codacya vastaava, hieman kauemmin markkinoilla ollut koodin staattisen analyysin verkossa toimiva palvelu. Code Climate ei tue Javaa, mutta on muuten erittäin hyväksi havaittu palvelu.
+[Code Climate](https://codeclimate.com) on codacya vastaava, hieman kauemmin markkinoilla ollut koodin staattisen analyysin verkossa toimiva palvelu.
 
 ## 4. git: branchit [versionhallinta]
 

--- a/laskarit/2.md
+++ b/laskarit/2.md
@@ -382,7 +382,7 @@ Virheen syynä on se, että githubissa oleva __master__-haara oli edellä paikal
 
 Tutustuimme viime viikon [tehtävissä 14-16](https://github.com/mluukkai/ohjelmistotuotanto2018/blob/master/laskarit/1.md#14-riippuvuuksien-injektointi-osa-1) riippuvuuksien injektointiin ja sovelsimme sitä testauksen helpottamiseen.
 
-Jos asia on päässyt unohtumaan, voit kerrata viime vuoden materiaalista
+Jos asia on päässyt unohtumaan, voit kerrata viime viikon materiaalista
 https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/web/riippuvuuksien_injektointi.md
 
 Kurssirepositorion hakemistossa [koodi/viikko2/Verkkokauppa1](https://github.com/mluukkai/Ohjelmistotuotanto2018/tree/master/koodi/viikko2/Verkkokauppa1) on yksinkertaisen verkkokaupan ohjelmakoodi


### PR DESCRIPTION
Palaute: Java 11 toimii suoraan, kunhan päivittää ensin Springin (3.1.1 -> 5.1.2 `build.gradle`:ssa) ja Gradlen (3.4.1 -> 4.10.2 `gradle/wrapper/gradlew-wrapper.properties`:ssa). Voisi olla vakiona uudemmat versiot tai lisätä päivitysohjeet johonkin.

Korjaukset:
* Code climate tukee javaa (https://codeclimate.com/java)
* Riippuvuuksien injektointi oli viime viikon materiaalia, ei viime vuoden.