### PR TITLE
Laskareiden 2 palautus

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@
 ## Laskarit
 
 [1](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/1.md) [2](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/2.md)
+
+THIS IS NOW A VANDALISED README
+MWAHAHAHAHAH

--- a/README.md
+++ b/README.md
@@ -2,14 +2,4 @@
 
 <https://github.com/mluukkai/ohjelmistotuotanto2018/wiki/Ohjelmistotuotanto-syksy-2018>
 
-## Luentokalvot
-
-[1](https://github.com/mluukkai/ohjelmistotuotanto2018/blob/master/kalvot/luento1.pdf?raw=true) [2](https://github.com/mluukkai/ohjelmistotuotanto2018/blob/master/kalvot/luento2.pdf?raw=true)
-
-
-## Laskarit
-
-[1](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/1.md) [2](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/2.md)
-
-THIS IS NOW A VANDALISED README
-MWAHAHAHAHAH
+# Laskareiden 2 palautus


### PR DESCRIPTION
Laskareiden tekoa hankaloitti jatkuvasti jäätyvä NetBeans (8.2, JDK1.8.0_191, macOS Sierra 10.12.6, yliopiston läppäri), piti vähän säätää että pystyi refaktoroimaan, ja lopputulos oli Javan downgradeeminen 8u151:een. Välilehtien siirtely hiirellä on edelleen vaarallista... Toinen tekninen säätö oli gitx/Sourcetreen kanssa - edellinen ei toimi uudemmilla, mutta toisaalta jälkimmäinen ei toimi minun ei-tarpeeksi-uudella käyttiksellä. Päädyin käyttämään rowanj-gitx sen sijaan, että lataisin vanhemman Sourcetreen.

Tehtävät vaikuttivat sopivan työläiltä, vaikka luettavaa tuntui olevan verrattain paljon. Pyrin kuitenkin lukemaan minimaalisesti kiireen vuoksi, tämä lukuvelka tulee ehkä maksettua takaisin myöhemmin...