### PR TITLE
Fix couple typos.

### DIFF
--- a/laskarit/4.md
+++ b/laskarit/4.md
@@ -396,4 +396,4 @@ palaute tehtävistä:
 * tee viikon 1 viimeisessä tehtävässä forkaamasi repositorioon jokin muutos
 * tee viime viikon tehtävän tapaan pull-request
   * anna tehtävistä palautetta avautuvaan lomakkeeseen
-  * huom: jos teeh tehtävät alkuviikosta, voi olla, että edellistä pull-requestiasi ei ole vielä ehditty hyväksyä ja et pääse vielä tekemään uutta requestia
+  * huom: jos teet tehtävät alkuviikosta, voi olla, että edellistä pull-requestiasi ei ole vielä ehditty hyväksyä ja et pääse vielä tekemään uutta requestia

--- a/laskarit/5.md
+++ b/laskarit/5.md
@@ -191,4 +191,4 @@ palaute tehtävistä:
 * tee viikon 1 viimeisessä tehtävässä forkaamasi repositorioon jokin muutos
 * tee viime viikon tehtävän tapaan pull-request
   * anna tehtävistä palautetta avautuvaan lomakkeeseen
-  * huom: jos teeh tehtävät alkuviikosta, voi olla, että edellistä pull-requestiasi ei ole vielä ehditty hyväksyä ja et pääse vielä tekemään uutta requestia
+  * huom: jos teet tehtävät alkuviikosta, voi olla, että edellistä pull-requestiasi ei ole vielä ehditty hyväksyä ja et pääse vielä tekemään uutta requestia

--- a/web/cucumber.md
+++ b/web/cucumber.md
@@ -186,6 +186,6 @@ Kun nyt suoritat testit, näyttää tulos seuraavalta:
 
 Eli cucumber ilmoittaa osan stepeistä olevan _undefined_. Cucumber tulostaa myös valmiin koodirungon, jonka avulla stepin voi toteuttaa.
 
-Kopioi stepin koorirunko stepit toteuttavaan luokkaan ja täydennä se järkevällä tavalla. 
+Kopioi stepin koodirunko stepit toteuttavaan luokkaan ja täydennä se järkevällä tavalla. 
 
 Varmista että testit toimivat.


### PR DESCRIPTION
Fix couple typos.

Palaute: Versionhallintaharjoituksissa voisi olla mukavampi "git stash pop" kuin "git stash apply", koska jälkimmäinen jättää vielä stashin paikalleen (git stash list) niin näitä sitten helposti kertyy vino pino.