### PR TITLE
Viikon 4 palaute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@
 ## Laskarit
 
 [1](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/1.md) [2](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/2.md) [3](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/3.md) [4](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/4.md) [5](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/5.md) [6](https://github.com/mluukkai/Ohjelmistotuotanto2018/blob/master/laskarit/6.md)
+


### PR DESCRIPTION
Hyvä, kevyt viikko.

MockitoDemossa oli käytössä deprecated mockiton Matchers joka on ilmeisesti siirretty jonkin hamcrest tiedostonimi confliktin vuoksi. Ei varmaan aiheuta ongelmia ennen kuin poistavat sen.