### PR TITLE
Korjaus erotus-metodin bTaulun poistoon

### DIFF
--- a/koodi/viikko5/IntJoukkoSovellus/src/main/java/ohtu/intjoukkosovellus/IntJoukko.java
+++ b/koodi/viikko5/IntJoukkoSovellus/src/main/java/ohtu/intjoukkosovellus/IntJoukko.java
@@ -186,7 +186,7 @@ public class IntJoukko {
             z.lisaa(aTaulu[i]);
         }
         for (int i = 0; i < bTaulu.length; i++) {
-            z.poista(i);
+            z.poista(bTaulu[i]);
         }
  
         return z;


### PR DESCRIPTION
Aikaisemmin metodi poisti loppu taulukosta indexin, eikä bTaulun sisältöä